### PR TITLE
Differentiate between benchmark and banks

### DIFF
--- a/R/plot_scatter.R
+++ b/R/plot_scatter.R
@@ -134,7 +134,7 @@ plot_scatter <- function(
       size = 3,
       hjust = 0
       ) +
-    geom_point() +
+    geom_point(aes(shape = .data$datapoint)) +
     scale_x_continuous(
       name = "Buildout",
       limits = c(-alignment_limit, alignment_limit),
@@ -153,6 +153,11 @@ plot_scatter <- function(
       midpoint = 0,
       limits = c(-alignment_limit, alignment_limit),
     ) +
+    scale_shape_manual(
+      name = "",
+      values = c("bank" = 16, "benchmark" = 21, "company" = 16, "other" = 16),
+      labels = r2dii.plot::to_title
+    ) +
     r2dii.plot::theme_2dii() +
     theme(
       panel.background = element_rect(fill = "#6c6c6c"),
@@ -164,6 +169,14 @@ plot_scatter <- function(
       subtitle = subtitle,
       caption = caption
     )
+
+  if (data_level == "company") {
+    p <- p +
+      guides(
+        shape = "none"
+      )
+  }
+
   p
 }
 

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -55,7 +55,16 @@ prep_scatter <- function(
       ) %>%
     select("name" = name_col, "direction", "value" = value_col) %>%
     distinct() %>%
-    tidyr::pivot_wider(names_from = "direction", values_from = "value")
+    tidyr::pivot_wider(names_from = "direction", values_from = "value") %>%
+    mutate(
+      datapoint = case_when(
+        grepl(".*[Bb]enchmark,*", .data$name) ~ "benchmark",
+        TRUE & (data_level == "bank") ~ "bank",
+        TRUE & (data_level == "company") ~ "company",
+        TRUE ~ "other"
+      )
+    )
+
   data_scatter
 }
 


### PR DESCRIPTION
Closes #26 

In this PR I add a shape aesthetic to differentiate between benchmark and bank. I switch off the shape legend in case the plot is made at a company level as in that base no benchmark is present. In the picture below benchmark overlaps with one of the banks, that's why it's not so visible (it's the dot that seems bigger) but I expect that in real-life example this will not be the case (I'm using a very limited test data here).

![image](https://user-images.githubusercontent.com/26434113/226359291-3e039801-c53c-42cc-ade9-52ddde613965.png)
