### PR TITLE
 rm outdated input arg from sda aggregation

### DIFF
--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -266,8 +266,6 @@ calculate_company_aggregate_alignment_tms <- function(data,
 #' Return company level sector alignment metric for each company
 #'
 #' @param data data.frame. Holds the PACTA for Banks SDA results on company level.
-#' @param scenario_emission_intensities data frame containing the scenario file with
-#'   information on yearly emission intensity levels.
 #' @param scenario_source Character. Vector that indicates which scenario_source
 #'   to use for reference in the calculation of the alignment metrics. Currently,
 #'   the only supported value is `"geco_2021"`.
@@ -277,7 +275,6 @@ calculate_company_aggregate_alignment_tms <- function(data,
 #' @return NULL
 #' @export
 calculate_company_aggregate_alignment_sda <- function(data,
-                                                      scenario_emission_intensities,
                                                       scenario_source = "geco_2021",
                                                       scenario = "1.5c") {
   # validate input values
@@ -287,10 +284,7 @@ calculate_company_aggregate_alignment_sda <- function(data,
   )
 
   # validate input data set
-  validate_input_data_calculate_company_aggregate_alignment_sda(
-    data = data,
-    scenario_emission_intensities = scenario_emission_intensities
-  )
+  validate_input_data_calculate_company_aggregate_alignment_sda(data = data)
 
   start_year <- min(data$year, na.rm = TRUE)
   target_scenario <- paste0("target_", scenario)
@@ -444,21 +438,12 @@ validate_input_args_calculate_company_aggregate_alignment_sda <- function(scenar
 }
 
 
-validate_input_data_calculate_company_aggregate_alignment_sda <- function(data,
-                                                                          scenario_emission_intensities) {
+validate_input_data_calculate_company_aggregate_alignment_sda <- function(data) {
   validate_data_has_expected_cols(
     data = data,
     expected_columns <- c(
       "sector", "year", "region", "scenario_source", "name_abcd",
       "emission_factor_metric", "emission_factor_value", "group_id"
-    )
-  )
-
-  validate_data_has_expected_cols(
-    data = scenario_emission_intensities,
-    expected_columns <- c(
-      "scenario_source", "scenario", "sector", "region", "year",
-      "emission_factor", "emission_factor_unit"
     )
   )
 

--- a/man/calculate_company_aggregate_alignment_sda.Rd
+++ b/man/calculate_company_aggregate_alignment_sda.Rd
@@ -6,16 +6,12 @@
 \usage{
 calculate_company_aggregate_alignment_sda(
   data,
-  scenario_emission_intensities,
   scenario_source = "geco_2021",
   scenario = "1.5c"
 )
 }
 \arguments{
 \item{data}{data.frame. Holds the PACTA for Banks SDA results on company level.}
-
-\item{scenario_emission_intensities}{data frame containing the scenario file with
-information on yearly emission intensity levels.}
 
 \item{scenario_source}{Character. Vector that indicates which scenario_source
 to use for reference in the calculation of the alignment metrics. Currently,


### PR DESCRIPTION
the argument `scenario_emission_intensities` was not used anymore in the function `calculate_company_aggregate_alignment_sda()` beyond the data input check. It can therefore be removed.