### PR TITLE
use pacta.pkgdown.template for formatting the github page

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,11 +1,5 @@
-destination: docs
-development:
-  mode: auto
-template:
-  bootstrap: 5
-  params:
-    bootswatch: flatly
 url: https://rmi-pacta.github.io/pacta.aggregate.loanbook.plots
+package: pacta.pkgdown.template
 navbar:
   type: default
   left:


### PR DESCRIPTION
closes #66 

w.i.p

comparing what this produces locally with e.g. https://rmi-pacta.github.io/pacta.portfolio.analysis/, there still remains some work to do, as the color theme does not appear to come through yet