### PR TITLE
remove custom options to align with pkgdown template

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,14 +1,3 @@
 url: https://rmi-pacta.github.io/pacta.aggregate.loanbook.plots
 template:
   package: pacta.pkgdown.template
-navbar:
-  type: default
-  left:
-  - text: Reference
-    href: reference/index.html
-  - text: Articles
-    menu:
-    - text: Company alignment metric
-      href: articles/company_alignment_metric.html
-    - text: Exposure-weighted aggregated alignment metric
-      href: articles/loanbook_aggregated_alignment_metric.html


### PR DESCRIPTION
These custom options prevent the pkgdown site from being aligned with the pacta.pkgdwon.template.

FYI, I fixed the problem with the header/navbar text not being the right color, so it will look nice this time, e.g. https://rmi-pacta.github.io/pacta.data.preparation/