### PR TITLE
Test and refactor agg sda

### DIFF
--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -359,7 +359,8 @@ calculate_company_aggregate_alignment_sda <- function(data,
   validate_input_calculate_company_aggregate_alignment_sda(
     data = data,
     scenario_source = scenario_source,
-    scenario = scenario
+    scenario = scenario,
+    time_frame = time_frame
   )
 
   # params

--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -345,12 +345,16 @@ calculate_company_alignment_metric <- function(data,
 #'   the only supported value is `"geco_2021"`.
 #' @param scenario Character. Vector that indicates which scenario to calculate
 #'   the alignment metric for. Must be a scenario available from `scenario_source`.
+#' @param time_frame Integer of length one. The number of forward looking years
+#'   that should be considered in the analysis. Standard `time_frame` in PACTA
+#'   is five years.
 #'
 #' @return NULL
 #' @export
 calculate_company_aggregate_alignment_sda <- function(data,
                                                       scenario_source = "geco_2021",
-                                                      scenario = "1.5c") {
+                                                      scenario = "1.5c",
+                                                      time_frame = 5L) {
   # validate inputs
   validate_input_calculate_company_aggregate_alignment_sda(
     data = data,
@@ -361,7 +365,6 @@ calculate_company_aggregate_alignment_sda <- function(data,
   # params
   start_year <- min(data$year, na.rm = TRUE)
   # standard forward looking PACTA time frame
-  time_frame <- 5
   target_scenario <- paste0("target_", scenario)
   # since sda sectors are not split into technologies, the level is always: "net"
   level <- "net"
@@ -621,11 +624,13 @@ check_consistency_calculate_company_aggregate_alignment_tms <- function(data,
 
 validate_input_calculate_company_aggregate_alignment_sda <- function(data,
                                                                      scenario_source,
-                                                                     scenario) {
+                                                                     scenario,
+                                                                     time_frame) {
   # validate input values
   validate_input_args_calculate_company_aggregate_alignment_sda(
     scenario_source = scenario_source,
-    scenario = scenario
+    scenario = scenario,
+    time_frame = time_frame
   )
 
   # validate input data set
@@ -644,7 +649,8 @@ validate_input_calculate_company_aggregate_alignment_sda <- function(data,
 }
 
 validate_input_args_calculate_company_aggregate_alignment_sda <- function(scenario_source,
-                                                                          scenario) {
+                                                                          scenario,
+                                                                          time_frame) {
   if (!length(scenario_source) == 1) {
     stop("Argument scenario_source must be of length 1. Please check your input.")
   }
@@ -656,6 +662,12 @@ validate_input_args_calculate_company_aggregate_alignment_sda <- function(scenar
   }
   if (!inherits(scenario, "character")) {
     stop("Argument scenario must be of length 1. Please check your input.")
+  }
+  if (!length(time_frame) == 1) {
+    stop("Argument scenario must be of length 1. Please check your input.")
+  }
+  if (!inherits(time_frame, "integer")) {
+    stop("Argument time_frame must be of class integer. Please check your input.")
   }
 
   invisible()

--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -80,6 +80,8 @@ prep_company_alignment_aggregation <- function(data,
                                                scenario_source,
                                                scenario) {
   start_year <- min(data$year, na.rm = TRUE)
+  # standard forward looking PACTA time frame
+  time_frame <- 5
 
   technology_direction <- technology_direction %>%
     dplyr::filter(
@@ -94,7 +96,7 @@ prep_company_alignment_aggregation <- function(data,
   data <- data %>%
     dplyr::select(-c("technology_share", "scope", "percentage_of_initial_production_by_scope")) %>%
     dplyr::filter(.data$metric %in% c("projected", paste0("target_", .env$scenario))) %>%
-    dplyr::filter(dplyr::between(.data$year, left = .env$start_year, right = .env$start_year + 5)) %>%
+    dplyr::filter(dplyr::between(.data$year, left = .env$start_year, right = .env$start_year + .env$time_frame)) %>%
     tidyr::pivot_wider(
       names_from = "metric",
       values_from = "production"
@@ -356,7 +358,10 @@ calculate_company_aggregate_alignment_sda <- function(data,
     scenario = scenario
   )
 
+  # params
   start_year <- min(data$year, na.rm = TRUE)
+  # standard forward looking PACTA time frame
+  time_frame <- 5
   target_scenario <- paste0("target_", scenario)
   # since sda sectors are not split into technologies, the level is always: "net"
   level <- "net"
@@ -365,7 +370,9 @@ calculate_company_aggregate_alignment_sda <- function(data,
   data <- data %>%
     prep_and_wrangle_aggregate_alignment_sda(
       scenario_source = scenario_source,
-      target_scenario = target_scenario
+      target_scenario = target_scenario,
+      start_year = start_year,
+      time_frame = time_frame
     )
 
   # add activity units to data
@@ -398,12 +405,18 @@ calculate_company_aggregate_alignment_sda <- function(data,
 prep_and_wrangle_aggregate_alignment_sda <- function(data,
                                                      scenario_source,
                                                      target_scenario,
-                                                     start_year) {
+                                                     start_year,
+                                                     time_frame) {
   data <- data %>%
     dplyr::filter(.data$scenario_source == .env$scenario_source) %>%
     dplyr::filter(.data$name_abcd != "market") %>%
     dplyr::filter(.data$emission_factor_metric %in% c("projected", .env$target_scenario)) %>%
-    dplyr::filter(dplyr::between(.data$year, left = .env$start_year, right = .env$start_year + 5)) %>%
+    dplyr::filter(
+      dplyr::between(
+        .data$year,
+        left = .env$start_year,
+        right = .env$start_year + .env$time_frame)
+    ) %>%
     tidyr::pivot_wider(
       names_from = "emission_factor_metric",
       values_from = "emission_factor_value"

--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -18,6 +18,9 @@
 #'   metric can be treated differently than for other technologies. Currently,
 #'   the only allowed values are (`"none", "gascap"`). Default is `"none"` which
 #'   means that no special calculations are applied to any technology.
+#' @param time_frame Integer of length one. The number of forward looking years
+#'   that should be considered in the analysis. Standard `time_frame` in PACTA
+#'   is five years.
 #'
 #' @return NULL
 #' @export
@@ -25,7 +28,8 @@ calculate_company_tech_deviation <- function(data,
                                              technology_direction,
                                              scenario_source = "geco_2021",
                                              scenario = "1.5c",
-                                             bridge_tech = c("none", "gascap")) {
+                                             bridge_tech = c("none", "gascap"),
+                                             time_frame = 5L) {
   bridge_tech <- rlang::arg_match(bridge_tech)
 
   # validate inputs
@@ -34,7 +38,8 @@ calculate_company_tech_deviation <- function(data,
     technology_direction = technology_direction,
     scenario_source = scenario_source,
     scenario = scenario,
-    bridge_tech = bridge_tech
+    bridge_tech = bridge_tech,
+    time_frame = time_frame
   )
 
   # prep and wrangle data for calculation of company tech deviations
@@ -44,7 +49,8 @@ calculate_company_tech_deviation <- function(data,
     prep_company_alignment_aggregation(
       technology_direction = technology_direction,
       scenario_source = scenario_source,
-      scenario = scenario
+      scenario = scenario,
+      time_frame = time_frame
     )
 
   # remove rows with inadequate values
@@ -78,10 +84,9 @@ calculate_company_tech_deviation <- function(data,
 prep_company_alignment_aggregation <- function(data,
                                                technology_direction,
                                                scenario_source,
-                                               scenario) {
+                                               scenario,
+                                               time_frame) {
   start_year <- min(data$year, na.rm = TRUE)
-  # standard forward looking PACTA time frame
-  time_frame <- 5
 
   technology_direction <- technology_direction %>%
     dplyr::filter(
@@ -445,12 +450,14 @@ validate_input_calculate_company_tech_deviation <- function(data,
                                                             technology_direction,
                                                             scenario_source,
                                                             scenario,
-                                                            bridge_tech) {
+                                                            bridge_tech,
+                                                            time_frame) {
   # validate input values
   validate_input_args_calculate_company_tech_deviation(
     scenario_source = scenario_source,
     scenario = scenario,
-    bridge_tech = bridge_tech
+    bridge_tech = bridge_tech,
+    time_frame = time_frame
   )
 
   # validate input data sets
@@ -508,7 +515,8 @@ validate_input_calculate_company_tech_deviation <- function(data,
 
 validate_input_args_calculate_company_tech_deviation <- function(scenario_source,
                                                                  scenario,
-                                                                 bridge_tech) {
+                                                                 bridge_tech,
+                                                                 time_frame) {
   if (!length(scenario_source) == 1) {
     stop("Argument scenario_source must be of length 1. Please check your input.")
   }
@@ -526,6 +534,12 @@ validate_input_args_calculate_company_tech_deviation <- function(scenario_source
   }
   if (!inherits(bridge_tech, "character")) {
     stop("Argument bridge_tech must be of class character. Please check your input.")
+  }
+  if (!length(time_frame) == 1) {
+    stop("Argument time_frame must be of length 1. Please check your input.")
+  }
+  if (!inherits(time_frame, "integer")) {
+    stop("Argument time_frame must be of class integer Please check your input.")
   }
 
   invisible()

--- a/R/calculate_company_alignment_metric.R
+++ b/R/calculate_company_alignment_metric.R
@@ -661,7 +661,7 @@ validate_input_args_calculate_company_aggregate_alignment_sda <- function(scenar
     stop("Argument scenario must be of length 1. Please check your input.")
   }
   if (!inherits(scenario, "character")) {
-    stop("Argument scenario must be of length 1. Please check your input.")
+    stop("Argument scenario must be of class character. Please check your input.")
   }
   if (!length(time_frame) == 1) {
     stop("Argument scenario must be of length 1. Please check your input.")

--- a/man/calculate_company_aggregate_alignment_sda.Rd
+++ b/man/calculate_company_aggregate_alignment_sda.Rd
@@ -7,7 +7,8 @@
 calculate_company_aggregate_alignment_sda(
   data,
   scenario_source = "geco_2021",
-  scenario = "1.5c"
+  scenario = "1.5c",
+  time_frame = 5L
 )
 }
 \arguments{
@@ -19,6 +20,10 @@ the only supported value is \code{"geco_2021"}.}
 
 \item{scenario}{Character. Vector that indicates which scenario to calculate
 the alignment metric for. Must be a scenario available from \code{scenario_source}.}
+
+\item{time_frame}{Integer of length one. The number of forward looking years
+that should be considered in the analysis. Standard \code{time_frame} in PACTA
+is five years.}
 }
 \description{
 Return company level sector alignment metric for each company

--- a/man/calculate_company_tech_deviation.Rd
+++ b/man/calculate_company_tech_deviation.Rd
@@ -11,7 +11,8 @@ calculate_company_tech_deviation(
   technology_direction,
   scenario_source = "geco_2021",
   scenario = "1.5c",
-  bridge_tech = c("none", "gascap")
+  bridge_tech = c("none", "gascap"),
+  time_frame = 5L
 )
 }
 \arguments{
@@ -35,6 +36,10 @@ build out despite the need for a long term phase down. If so, the alignment
 metric can be treated differently than for other technologies. Currently,
 the only allowed values are (\verb{"none", "gascap"}). Default is \code{"none"} which
 means that no special calculations are applied to any technology.}
+
+\item{time_frame}{Integer of length one. The number of forward looking years
+that should be considered in the analysis. Standard \code{time_frame} in PACTA
+is five years.}
 }
 \description{
 Return company level technology deviations for TMS sectors. To be used as

--- a/tests/testthat/test-calculate_company_alignment_metric.R
+++ b/tests/testthat/test-calculate_company_alignment_metric.R
@@ -18,13 +18,15 @@ test_technology_direction <- tibble::tribble(
 test_scenario_source <- "scenario_source"
 test_scenario <- "scenario"
 test_bridge_tech <- "none"
+test_time_frame <- 5L
 
 test_output_calculate_company_tech_deviation <- calculate_company_tech_deviation(
   data = test_data_calculate_company_tech_deviation,
   technology_direction = test_technology_direction,
   scenario_source = test_scenario_source,
   scenario = test_scenario,
-  bridge_tech = test_bridge_tech
+  bridge_tech = test_bridge_tech,
+  time_frame = test_time_frame
 )
 
 test_that("calculate_company_tech_deviation returns deviations and directions as expected", {

--- a/tests/testthat/test-calculate_company_alignment_metric.R
+++ b/tests/testthat/test-calculate_company_alignment_metric.R
@@ -463,6 +463,41 @@ test_that("calculate_company_alignment_metric calculates company alignment metri
 })
 
 # calculate_company_aggregate_alignment_sda----
+# styler: off
+test_data_calculate_company_aggregate_alignment_sda <- tibble::tribble(
+  ~sector, ~year,  ~region, ~scenario_source,  ~name_abcd,    ~group_id, ~emission_factor_metric, ~emission_factor_value,
+  "steel",  2027, "global",    "test_source", "company_A", "test_group",             "projected",                    0.8,
+  "steel",  2027, "global",    "test_source", "company_A", "test_group",       "target_scenario",                    0.7,
+  "steel",  2027, "global",    "test_source", "company_B", "test_group",             "projected",                   0.55,
+  "steel",  2027, "global",    "test_source", "company_B", "test_group",       "target_scenario",                    0.6
+)
+# styler: on
+
+test_scenario_source <- "test_source"
+test_scenario <- "scenario"
+
+test_output_calculate_company_aggregate_alignment_sda <- calculate_company_aggregate_alignment_sda(
+  data = test_data_calculate_company_aggregate_alignment_sda,
+  scenario_source = test_scenario_source,
+  scenario = test_scenario
+)
+
+added_columns <- c("activity_unit", "scenario", "direction", "total_deviation", "technology_share_by_direction", "alignment_metric")
+dropped_columns <- c("emission_factor_metric", "emission_factor_value")
+expected_output_columns <- c(names(test_data_calculate_company_aggregate_alignment_sda), added_columns)
+expected_output_columns <- expected_output_columns[!expected_output_columns %in% dropped_columns]
+
+expected_output_rows <- test_data_calculate_company_aggregate_alignment_sda %>%
+  dplyr::distinct(.data$sector, .data$year, .data$region, .data$scenario_source, .data$name_abcd, .data$group_id) %>%
+  nrow()
+
+test_that("calculate_company_aggregate_alignment_sda returns expected structure of outputs", {
+  expect_equal(sort(names(test_output_calculate_company_aggregate_alignment_sda)), sort(expected_output_columns))
+  expect_equal(nrow(test_output_calculate_company_aggregate_alignment_sda), expected_output_rows)
+  expect_equal(unique(test_output_calculate_company_aggregate_alignment_sda$direction), "net")
+  expect_equal(unique(test_output_calculate_company_aggregate_alignment_sda$scenario), test_scenario)
+})
+
 ## check_consistency_calculate_company_aggregate_alignment_sda----
 # styler: off
 test_data_consistency_sda_1 <- tibble::tribble(

--- a/tests/testthat/test-calculate_company_alignment_metric.R
+++ b/tests/testthat/test-calculate_company_alignment_metric.R
@@ -475,11 +475,13 @@ test_data_calculate_company_aggregate_alignment_sda <- tibble::tribble(
 
 test_scenario_source <- "test_source"
 test_scenario <- "scenario"
+test_time_frame <- 5L
 
 test_output_calculate_company_aggregate_alignment_sda <- calculate_company_aggregate_alignment_sda(
   data = test_data_calculate_company_aggregate_alignment_sda,
   scenario_source = test_scenario_source,
-  scenario = test_scenario
+  scenario = test_scenario,
+  time_frame = test_time_frame
 )
 
 added_columns <- c("activity_unit", "scenario", "direction", "total_deviation", "technology_share_by_direction", "alignment_metric")
@@ -560,7 +562,7 @@ test_data_prep_and_wrangle_aggregate_alignment_sda_1 <- tibble::tribble(
 test_scenario_source <- "scenario_source"
 test_target_scenario <- "target_scenario"
 test_start_year <- 2022
-test_time_frame <- 5
+test_time_frame <- 5L
 
 test_output_prep_and_wrangle_aggregate_alignment_sda_1 <- prep_and_wrangle_aggregate_alignment_sda(
   data = test_data_prep_and_wrangle_aggregate_alignment_sda_1,
@@ -600,22 +602,24 @@ test_data_prep_and_wrangle_aggregate_alignment_sda_2 <- tibble::tribble(
   "scenario_source", "test_company",  2021,       "target_scenario",                    0.9,
   "scenario_source", "test_company",  2022,             "projected",                    0.9,
   "scenario_source", "test_company",  2022,       "target_scenario",                    0.9,
-  "scenario_source", "test_company",  2028,             "projected",                    0.8,
-  "scenario_source", "test_company",  2028,       "target_scenario",                    0.7
+  "scenario_source", "test_company",  2027,             "projected",                    0.8,
+  "scenario_source", "test_company",  2027,       "target_scenario",                    0.7
 )
 # styler: on
+
+test_time_frame_short <- 4L
 
 test_output_prep_and_wrangle_aggregate_alignment_sda_2 <- prep_and_wrangle_aggregate_alignment_sda(
   data = test_data_prep_and_wrangle_aggregate_alignment_sda_2,
   scenario_source = test_scenario_source,
   target_scenario = test_target_scenario,
   start_year = test_start_year,
-  time_frame = test_time_frame
+  time_frame = test_time_frame_short
 )
 
 test_output_years <- unique(test_output_prep_and_wrangle_aggregate_alignment_sda_2$year)
 expected_output_year <- test_data_prep_and_wrangle_aggregate_alignment_sda_2 %>%
-  dplyr::filter(dplyr::between(.data$year, test_start_year, test_start_year + test_time_frame)) %>%
+  dplyr::filter(dplyr::between(.data$year, test_start_year, test_start_year + test_time_frame_short)) %>%
   dplyr::pull(.data$year) %>%
   unique()
 


### PR DESCRIPTION
relates to #46 

This PR:
- refactors `calculate_company_aggregate_alignment_sda()` so that it follows the structure of `calculate_company_aggregate_alignment_tms()` much more closely
- adds unit tests for `calculate_company_aggregate_alignment_sda()`
- surfaces `time_frame` as a function argument to avoid using magic numbers