### PR TITLE
Reorder sankey plot

### DIFF
--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -32,6 +32,12 @@ plot_sankey <- function(
         group_id = r2dii.plot::to_title(.data$group_id),
         middle_node = r2dii.plot::to_title(.data$middle_node)
         )
+    if ("middle_node2" %in% names(data_links)) {
+    data_links <- data_links %>%
+      mutate(
+        middle_node2 = r2dii.plot::to_title(.data$middle_node2)
+      )
+      }
   } else {
     data_links <- data
   }

--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -63,8 +63,7 @@ plot_sankey <- function(
         group = "is_aligned"
         )
 
-    links <- bind_rows(links_1, links_2, links_3) %>%
-      as.data.frame()
+    links <- bind_rows(links_1, links_2, links_3)
   } else {
    links_2 <- data_links %>%
     select(
@@ -75,9 +74,15 @@ plot_sankey <- function(
       group = "is_aligned"
       )
 
-   links <- bind_rows(links_1, links_2) %>%
-    as.data.frame()
+   links <- bind_rows(links_1, links_2)
   }
+
+  links <- links %>%
+    group_by(.data$source, .data$target, .data$group) %>%
+    summarise(value = sum(.data$value, na.rm = TRUE)) %>%
+    ungroup() %>%
+    arrange(.data$source, .data$group) %>%
+    as.data.frame()
 
   # TODO: colour the companies if fully aligned or not
   nodes <- data.frame(

--- a/R/prep_sankey.R
+++ b/R/prep_sankey.R
@@ -54,7 +54,11 @@ prep_sankey <- function(
       ),
       middle_node =!! sym(middle_node)
       ) %>%
-    select("group_id", "middle_node", "is_aligned", "loan_size_outstanding")
+    select("group_id", "middle_node", "is_aligned", "loan_size_outstanding") %>%
+      group_by(.data$group_id, .data$middle_node, .data$is_aligned) %>%
+       summarise(loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE)) %>%
+       ungroup() %>%
+      arrange(.data$group_id, .data$is_aligned)
   } else {
     data_out <- data_alignment %>%
     inner_join(matched_loanbook, by = c("group_id", "name_abcd", "sector")) %>%
@@ -67,7 +71,11 @@ prep_sankey <- function(
       middle_node =!! sym(middle_node),
       middle_node2 =!! sym(middle_node2)
       ) %>%
-    select("group_id", "middle_node", "middle_node2", "is_aligned", "loan_size_outstanding")
+    select("group_id", "middle_node", "middle_node2", "is_aligned", "loan_size_outstanding") %>%
+      group_by(.data$group_id, .data$middle_node, .data$middle_node2, .data$is_aligned) %>%
+       summarise(loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE)) %>%
+       ungroup() %>%
+      arrange(.data$group_id, .data$is_aligned)
   }
   data_out
 }

--- a/man/plot_sankey.Rd
+++ b/man/plot_sankey.Rd
@@ -8,7 +8,8 @@ plot_sankey(
   data,
   capitalise_node_labels = TRUE,
   save_png_to = NULL,
-  png_name = "sankey.png"
+  png_name = "sankey.png",
+  nodes_order_from_data = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,10 @@ be converted into better looking capitalised form.}
 saved}
 
 \item{png_name}{Character. File name of the output.}
+
+\item{nodes_order_from_data}{Logical. Flag indicating if nodes order should
+be determined by an algorithm (in case of big datasets often results in a
+better looking plot) or should they be ordered based on data.}
 }
 \description{
 Make a sankey plot


### PR DESCRIPTION
In this PR I:
* add an option for order of the plot to be determined from data (this is only partially possible)
* group the links to improve visual flow
* fix a small bug - second order nodes were not cpaitalised