### PR TITLE
aggregate bopo correctly

### DIFF
--- a/R/aggregate_alignment_loanbook_exposure.R
+++ b/R/aggregate_alignment_loanbook_exposure.R
@@ -58,6 +58,9 @@ aggregate_alignment_loanbook_exposure <- function(data,
       share_companies_aligned = .data$n_companies_aligned / .data$n_companies
     )
 
+  # aggregate exposure of aligned companies can only be calculated reasonably
+  # for the net level, not the buildout/phaseout level since we cannot assume
+  # the loan is split based on output units.
   if (level == "net") {
     sector_aggregate_exposure_loanbook_summary_value <- aggregate_exposure_company %>%
       dplyr::mutate(

--- a/R/aggregate_alignment_loanbook_exposure.R
+++ b/R/aggregate_alignment_loanbook_exposure.R
@@ -2,7 +2,7 @@
 #'
 #' @param data data.frame. Holds output pf company indicators
 #' @param matched data.frame. Holds matched and prioritised loan book
-#' @param level Character. Vector that indicates if the aggreagte alignment
+#' @param level Character. Vector that indicates if the aggregate alignment
 #'   metric should be returned based on the net technology deviations (`net`) or
 #'   disaggregated into buildout and phaseout technologies (`bo_po`).
 #'
@@ -12,7 +12,7 @@ aggregate_alignment_loanbook_exposure <- function(data,
                                                   matched,
                                                   level = c("net", "bo_po")) {
   group_vars <- c("group_id", "scenario", "region", "sector", "year", "direction")
-  level <- match.arg(level)
+  level <- rlang::arg_match(level)
 
   # validate input data sets
   validate_input_data_aggregate_alignment_loanbook_exposure(

--- a/R/aggregate_alignment_loanbook_exposure.R
+++ b/R/aggregate_alignment_loanbook_exposure.R
@@ -2,17 +2,11 @@
 #'
 #' @param data data.frame. Holds output pf company indicators
 #' @param matched data.frame. Holds matched and prioritised loan book
-#' @param level Character. Vector that indicates if the aggregate alignment
-#'   metric should be returned based on the net technology deviations (`net`) or
-#'   disaggregated into buildout and phaseout technologies (`bo_po`).
 #'
 #' @return NULL
 #' @export
 aggregate_alignment_loanbook_exposure <- function(data,
-                                                  matched,
-                                                  level = c("net", "bo_po")) {
-  level <- rlang::arg_match(level)
-
+                                                  matched) {
   # validate input data sets
   validate_input_data_aggregate_alignment_loanbook_exposure(
     data = data,
@@ -44,16 +38,6 @@ aggregate_alignment_loanbook_exposure <- function(data,
       matched,
       by = c("group_id", "name_abcd", "sector")
     )
-
-  # if we aggregate to the buildout/phaseout level, we need to split the
-  # exposure weights according to the technology_share_by_direction.
-  # if we aggregate to the net level, we just keep the net exposure weights per company
-  if (level == "bo_po") {
-    aggregate_exposure_company <- aggregate_exposure_company %>%
-      dplyr::mutate(
-        exposure_weight = .data$exposure_weight * .data$technology_share_by_direction
-      )
-  }
 
   sector_aggregate_exposure_loanbook <- aggregate_exposure_company %>%
     dplyr::group_by(.data$group_id, .data$region, .data$scenario, .data$sector, .data$year, .data$direction) %>%

--- a/R/aggregate_alignment_loanbook_exposure.R
+++ b/R/aggregate_alignment_loanbook_exposure.R
@@ -2,15 +2,24 @@
 #'
 #' @param data data.frame. Holds output pf company indicators
 #' @param matched data.frame. Holds matched and prioritised loan book
+#' @param level Character. Vector that indicates if the aggreagte alignment
+#'   metric should be returned based on the net technology deviations (`net`) or
+#'   disaggregated into buildout and phaseout technologies (`bo_po`).
 #'
 #' @return NULL
 #' @export
 aggregate_alignment_loanbook_exposure <- function(data,
-                                                  matched) {
+                                                  matched,
+                                                  level = c("net", "bo_po")) {
+
+  group_vars <- c("group_id", "scenario", "region", "sector", "year", "direction")
+  level <- match.arg(level)
+
   # validate input data sets
   validate_input_data_aggregate_alignment_loanbook_exposure(
     data = data,
-    matched = matched
+    matched = matched,
+    group_vars = group_vars
   )
 
   matched <- matched %>%
@@ -38,7 +47,7 @@ aggregate_alignment_loanbook_exposure <- function(data,
     dplyr::mutate(
       n_companies = dplyr::n(),
       sum_loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE),
-      .by = c("group_id", "region", "scenario", "sector", "year", "direction")
+      .by = group_vars
     ) %>%
     dplyr::mutate(
       companies_aligned = dplyr::if_else(.data$alignment_metric >= 0, TRUE, FALSE),
@@ -47,10 +56,7 @@ aggregate_alignment_loanbook_exposure <- function(data,
     dplyr::summarise(
       n_companies_aligned = sum(.data$companies_aligned, na.rm = TRUE),
       sum_exposure_companies_aligned = sum(.data$exposure_companies_aligned, na.rm = TRUE),
-      .by = c(
-        "group_id", "n_companies", "sum_loan_size_outstanding",
-        "scenario", "region", "sector", "year", "direction"
-      )
+      .by = c(group_vars, "n_companies", "sum_loan_size_outstanding")
     ) %>%
     dplyr::mutate(
       share_companies_aligned = .data$n_companies_aligned / .data$n_companies,
@@ -60,13 +66,13 @@ aggregate_alignment_loanbook_exposure <- function(data,
   # if a company only has technologies going in one direction in a sector with
   # high carbon and low carbon technologies, add an empty entry for the other
   # direction to ensure the aggregation is correct
-  if (all(unique(aggregate_exposure_company$direction) %in% c("buildout", "phaseout"))) {
+  if (level == "bo_po") {
     aggregate_exposure_company <- aggregate_exposure_company %>%
       dplyr::mutate(
         n_directions = dplyr::n(),
         .by = c(
-          "group_id", "name_abcd", "sector", "activity_unit", "region",
-          "scenario_source", "scenario", "year", "loan_size_outstanding_currency"
+          group_vars[!group_vars == "direction"], "name_abcd", "sector",
+          "activity_unit", "loan_size_outstanding_currency"
         )
       )
 
@@ -96,20 +102,17 @@ aggregate_alignment_loanbook_exposure <- function(data,
   sector_aggregate_exposure_loanbook_alignment <- aggregate_exposure_company %>%
     dplyr::summarise(
       exposure_weighted_net_alignment = stats::weighted.mean(.data$alignment_metric, w = .data$exposure_weight, na.rm = TRUE),
-      .by = c(
-        "group_id", "scenario", "region", "sector", "year", "direction"
-      )
+      .by = group_vars
     )
 
   out <- sector_aggregate_exposure_loanbook_summary %>%
     dplyr::inner_join(
       sector_aggregate_exposure_loanbook_alignment,
-      by = c("group_id", "scenario", "region", "sector", "year", "direction")
+      by = group_vars
     ) %>%
     dplyr::relocate(
       c(
-        "group_id", "scenario", "region", "sector", "year", "direction",
-        "n_companies", "n_companies_aligned", "share_companies_aligned",
+        group_vars, "n_companies", "n_companies_aligned", "share_companies_aligned",
         "sum_loan_size_outstanding", "sum_exposure_companies_aligned",
         "share_exposure_aligned", "exposure_weighted_net_alignment"
       )
@@ -120,12 +123,12 @@ aggregate_alignment_loanbook_exposure <- function(data,
 }
 
 validate_input_data_aggregate_alignment_loanbook_exposure <- function(data,
-                                                                      matched) {
+                                                                      matched,
+                                                                      group_vars) {
   validate_data_has_expected_cols(
     data = data,
     expected_columns <- c(
-      "group_id", "name_abcd", "sector", "activity_unit", "region",
-      "scenario_source", "scenario", "year", "direction", "alignment_metric"
+      group_vars, "name_abcd", "activity_unit", "scenario_source", "alignment_metric"
     )
   )
 

--- a/man/aggregate_alignment_loanbook_exposure.Rd
+++ b/man/aggregate_alignment_loanbook_exposure.Rd
@@ -11,7 +11,7 @@ aggregate_alignment_loanbook_exposure(data, matched, level = c("net", "bo_po"))
 
 \item{matched}{data.frame. Holds matched and prioritised loan book}
 
-\item{level}{Character. Vector that indicates if the aggreagte alignment
+\item{level}{Character. Vector that indicates if the aggregate alignment
 metric should be returned based on the net technology deviations (\code{net}) or
 disaggregated into buildout and phaseout technologies (\code{bo_po}).}
 }

--- a/man/aggregate_alignment_loanbook_exposure.Rd
+++ b/man/aggregate_alignment_loanbook_exposure.Rd
@@ -4,16 +4,12 @@
 \alias{aggregate_alignment_loanbook_exposure}
 \title{Return loan book level aggregation of company alignment metrics by exposure}
 \usage{
-aggregate_alignment_loanbook_exposure(data, matched, level = c("net", "bo_po"))
+aggregate_alignment_loanbook_exposure(data, matched)
 }
 \arguments{
 \item{data}{data.frame. Holds output pf company indicators}
 
 \item{matched}{data.frame. Holds matched and prioritised loan book}
-
-\item{level}{Character. Vector that indicates if the aggregate alignment
-metric should be returned based on the net technology deviations (\code{net}) or
-disaggregated into buildout and phaseout technologies (\code{bo_po}).}
 }
 \description{
 Return loan book level aggregation of company alignment metrics by exposure

--- a/man/aggregate_alignment_loanbook_exposure.Rd
+++ b/man/aggregate_alignment_loanbook_exposure.Rd
@@ -4,12 +4,16 @@
 \alias{aggregate_alignment_loanbook_exposure}
 \title{Return loan book level aggregation of company alignment metrics by exposure}
 \usage{
-aggregate_alignment_loanbook_exposure(data, matched)
+aggregate_alignment_loanbook_exposure(data, matched, level = c("net", "bo_po"))
 }
 \arguments{
 \item{data}{data.frame. Holds output pf company indicators}
 
 \item{matched}{data.frame. Holds matched and prioritised loan book}
+
+\item{level}{Character. Vector that indicates if the aggreagte alignment
+metric should be returned based on the net technology deviations (\code{net}) or
+disaggregated into buildout and phaseout technologies (\code{bo_po}).}
 }
 \description{
 Return loan book level aggregation of company alignment metrics by exposure

--- a/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
+++ b/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
@@ -1,0 +1,61 @@
+# aggregate_alignment_loanbook_exposure----
+
+# styler: off
+test_data_aggregate_alignment_loanbook_exposure_net <- tibble::tribble(
+     ~group_id, ~name_abcd,       ~sector, ~activity_unit,  ~region, ~scenario_source,       ~scenario, ~year, ~direction, ~total_deviation, ~alignment_metric,
+  "test_group", "test_company_1", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",             -110,              -0.3,
+  "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",              -70,              -0.4,
+  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",              -40,              -0.2
+)
+# styler: on
+
+# styler: off
+test_data_aggregate_alignment_loanbook_exposure_bopo <- tibble::tribble(
+     ~group_id, ~name_abcd,       ~sector, ~activity_unit,  ~region, ~scenario_source,       ~scenario, ~year, ~direction, ~total_deviation, ~alignment_metric,
+  "test_group", "test_company_1", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "buildout",              -10,             -0.05,
+  "test_group", "test_company_1", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",             -100,             -0.25,
+  "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "buildout",              -50,             -0.35,
+  "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -20,             -0.05,
+  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -40,              -0.2
+)
+# styler: on
+
+# styler: off
+test_matched <- tibble::tribble(
+     ~group_id, ~id_loan, ~loan_size_outstanding, ~loan_size_outstanding_currency,       ~name_abcd, ~sector,
+  "test_group",     "L1",                 300000,                           "USD", "test_company_1", "power",
+  "test_group",     "L2",                 700000,                           "USD", "test_company_2", "power",
+  "test_group",     "L3",                1000000,                           "USD", "test_company_3", "power"
+)
+# styler: on
+
+test_output_aggregate_alignment_loanbook_exposure_net <- test_data_aggregate_alignment_loanbook_exposure_net %>%
+  aggregate_alignment_loanbook_exposure(matched = test_matched)
+
+test_output_aggregate_alignment_loanbook_exposure_bopo <- test_data_aggregate_alignment_loanbook_exposure_bopo %>%
+  aggregate_alignment_loanbook_exposure(matched = test_matched)
+
+test_that("aggregated net alignment equals sum of aggregated buildout and phaseout alignments", {
+  expect_equal(
+    test_output_aggregate_alignment_loanbook_exposure_net$exposure_weighted_net_alignment,
+    sum(test_output_aggregate_alignment_loanbook_exposure_bopo$exposure_weighted_net_alignment, na.rm = TRUE)
+  )
+})
+
+test_that("aggregated net loan size equals sum of aggregated buildout and phaseout loan size", {
+  expect_equal(
+    test_output_aggregate_alignment_loanbook_exposure_net$sum_loan_size_outstanding,
+    sum(test_output_aggregate_alignment_loanbook_exposure_bopo$sum_loan_size_outstanding, na.rm = TRUE)
+  )
+})
+
+test_that("aggregated loan size equals sum of matched loan size", {
+  expect_equal(
+    sum(test_output_aggregate_alignment_loanbook_exposure_bopo$sum_loan_size_outstanding, na.rm = TRUE),
+    sum(test_matched$loan_size_outstanding, na.rm = TRUE)
+  )
+  expect_equal(
+    sum(test_output_aggregate_alignment_loanbook_exposure_net$sum_loan_size_outstanding, na.rm = TRUE),
+    sum(test_matched$loan_size_outstanding, na.rm = TRUE)
+  )
+})

--- a/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
+++ b/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
@@ -84,7 +84,7 @@ test_that("number of identified companies equals unique list of companies in inp
 
   expect_equal(
     n_output_buildout,
-    n_companies_input_net
+    n_companies_input_buildout
   )
 
   n_companies_input_phaseout <- test_data_aggregate_alignment_loanbook_exposure_bopo %>%

--- a/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
+++ b/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
@@ -56,20 +56,48 @@ test_that("aggregated net alignment equals sum of aggregated buildout and phaseo
   )
 })
 
-test_that("aggregated net loan size equals sum of aggregated buildout and phaseout loan size", {
-  expect_equal(
-    test_output_aggregate_alignment_loanbook_exposure_net$sum_loan_size_outstanding,
-    sum(test_output_aggregate_alignment_loanbook_exposure_bopo$sum_loan_size_outstanding, na.rm = TRUE)
-  )
-})
-
-test_that("aggregated loan size equals sum of matched loan size", {
-  expect_equal(
-    sum(test_output_aggregate_alignment_loanbook_exposure_bopo$sum_loan_size_outstanding, na.rm = TRUE),
-    sum(test_matched$loan_size_outstanding, na.rm = TRUE)
-  )
+test_that("net aggregated loan size equals sum of matched loan size", {
   expect_equal(
     sum(test_output_aggregate_alignment_loanbook_exposure_net$sum_loan_size_outstanding, na.rm = TRUE),
     sum(test_matched$loan_size_outstanding, na.rm = TRUE)
+  )
+})
+
+test_that("number of identified companies equals unique list of companies in input data", {
+  n_companies_input_net <- length(unique(test_data_aggregate_alignment_loanbook_exposure_net$name_abcd))
+
+  expect_equal(
+    test_output_aggregate_alignment_loanbook_exposure_net$n_companies,
+    n_companies_input_net
+  )
+})
+
+test_that("number of identified companies equals unique list of companies in input data", {
+  n_companies_input_buildout <- test_data_aggregate_alignment_loanbook_exposure_bopo %>%
+    dplyr::filter(.data$direction == "buildout") %>%
+    dplyr::distinct(.data$name_abcd) %>%
+    nrow()
+
+  n_output_buildout <- test_output_aggregate_alignment_loanbook_exposure_bopo %>%
+    dplyr::filter(.data$direction == "buildout") %>%
+    dplyr::pull(.data$n_companies)
+
+  expect_equal(
+    n_output_buildout,
+    n_companies_input_net
+  )
+
+  n_companies_input_phaseout <- test_data_aggregate_alignment_loanbook_exposure_bopo %>%
+    dplyr::filter(.data$direction == "phaseout") %>%
+    dplyr::distinct(.data$name_abcd) %>%
+    nrow()
+
+  n_output_phaseout <- test_output_aggregate_alignment_loanbook_exposure_bopo %>%
+    dplyr::filter(.data$direction == "phaseout") %>%
+    dplyr::pull(.data$n_companies)
+
+  expect_equal(
+    n_output_phaseout,
+    n_companies_input_phaseout
   )
 })

--- a/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
+++ b/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
@@ -101,3 +101,13 @@ test_that("number of identified companies equals unique list of companies in inp
     n_companies_input_phaseout
   )
 })
+
+test_that("net aggregate results have the same columns as buildout/phaseout aggregate results, plus three columns on loan exposure", {
+  exposure_columns <- c("sum_loan_size_outstanding", "sum_exposure_companies_aligned", "share_exposure_aligned")
+
+  expect_equal(
+    c(names(test_output_aggregate_alignment_loanbook_exposure_bopo), exposure_columns),
+    names(test_output_aggregate_alignment_loanbook_exposure_net)
+  )
+})
+

--- a/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
+++ b/tests/testthat/test-aggregate_alignment_loanbook_exposure.R
@@ -5,7 +5,8 @@ test_data_aggregate_alignment_loanbook_exposure_net <- tibble::tribble(
      ~group_id, ~name_abcd,       ~sector, ~activity_unit,  ~region, ~scenario_source,       ~scenario, ~year, ~direction, ~total_deviation, ~alignment_metric,
   "test_group", "test_company_1", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",             -110,              -0.3,
   "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",              -70,              -0.4,
-  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",              -40,              -0.2
+  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",              -40,              -0.2,
+  "test_group", "test_company_4", "power",           "MW", "global",    "test_source", "test_scenario",  2027,      "net",               50,               0.1
 )
 # styler: on
 
@@ -16,7 +17,10 @@ test_data_aggregate_alignment_loanbook_exposure_bopo <- tibble::tribble(
   "test_group", "test_company_1", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",             -100,             -0.25,
   "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "buildout",              -50,             -0.35,
   "test_group", "test_company_2", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -20,             -0.05,
-  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -40,              -0.2
+  "test_group", "test_company_3", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -40,              -0.2,
+  "test_group", "test_company_4", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "buildout",               60,              0.15,
+  "test_group", "test_company_4", "power",           "MW", "global",    "test_source", "test_scenario",  2027, "phaseout",              -10,             -0.05
+
 )
 # styler: on
 
@@ -25,15 +29,25 @@ test_matched <- tibble::tribble(
      ~group_id, ~id_loan, ~loan_size_outstanding, ~loan_size_outstanding_currency,       ~name_abcd, ~sector,
   "test_group",     "L1",                 300000,                           "USD", "test_company_1", "power",
   "test_group",     "L2",                 700000,                           "USD", "test_company_2", "power",
-  "test_group",     "L3",                1000000,                           "USD", "test_company_3", "power"
+  "test_group",     "L3",                1000000,                           "USD", "test_company_3", "power",
+  "test_group",     "L4",                 500000,                           "USD", "test_company_4", "power"
 )
 # styler: on
 
+test_level_net <- "net"
+test_level_bopo <- "bo_po"
+
 test_output_aggregate_alignment_loanbook_exposure_net <- test_data_aggregate_alignment_loanbook_exposure_net %>%
-  aggregate_alignment_loanbook_exposure(matched = test_matched)
+  aggregate_alignment_loanbook_exposure(
+    matched = test_matched,
+    level = test_level_net
+  )
 
 test_output_aggregate_alignment_loanbook_exposure_bopo <- test_data_aggregate_alignment_loanbook_exposure_bopo %>%
-  aggregate_alignment_loanbook_exposure(matched = test_matched)
+  aggregate_alignment_loanbook_exposure(
+    matched = test_matched,
+    level = test_level_bopo
+  )
 
 test_that("aggregated net alignment equals sum of aggregated buildout and phaseout alignments", {
   expect_equal(

--- a/tests/testthat/test-calculate_company_alignment_metric.R
+++ b/tests/testthat/test-calculate_company_alignment_metric.R
@@ -257,9 +257,9 @@ test_that("total_tech_deviation is less or equal 0 for all technologies in bridg
 # calculate_company_aggregate_alignment_tms----
 # styler: off
 test_data_calculate_company_aggregate_alignment_tms <- tibble::tribble(
-  ~sector,     ~technology, ~year,  ~region, ~scenario_source,     ~name_abcd,    ~group_id, ~projected, ~target_scenario, ~direction, ~total_tech_deviation, ~activity_unit, ~technology_share_by_direction,
-  "power",        "gascap",  2027, "global",    "test_source", "test_company", "test_group",        100,               80, "phaseout",                   -20,           "MW",                              1,
-  "power", "renewablescap",  2027, "global",    "test_source", "test_company", "test_group",         32,               40, "buildout",                    -8,           "MW",                              1
+  ~sector,     ~technology, ~year,  ~region, ~scenario_source,     ~name_abcd,    ~group_id, ~projected, ~target_scenario, ~direction, ~total_tech_deviation, ~activity_unit,
+  "power",        "gascap",  2027, "global",    "test_source", "test_company", "test_group",        100,               80, "phaseout",                   -20,           "MW",
+  "power", "renewablescap",  2027, "global",    "test_source", "test_company", "test_group",         32,               40, "buildout",                    -8,           "MW"
 )
 # styler: on
 
@@ -320,66 +320,6 @@ test_that("consistency checks of calculate_company_aggregate_alignment_tms() pas
   )
 })
 
-## add_technology_share_by_direction----
-# styler: off
-test_data_add_technology_share_by_direction <- tibble::tribble(
-     ~sector, ~technology,   ~year,  ~region, ~scenario_source,     ~name_abcd, ~projected,    ~group_id, ~direction, ~activity_unit,
-  "sector_A", "technology_A", 2027, "global",    "test_source", "test_company",         10, "test_group", "buildout",    "test_unit",
-  "sector_A", "technology_B", 2027, "global",    "test_source", "test_company",         20, "test_group", "buildout",    "test_unit",
-  "sector_A", "technology_C", 2027, "global",    "test_source", "test_company",         20, "test_group", "phaseout",    "test_unit",
-  "sector_B", "technology_D", 2027, "global",    "test_source", "test_company",         20, "test_group", "buildout",    "test_unit",
-  "sector_B", "technology_E", 2027, "global",    "test_source", "test_company",         20, "test_group", "phaseout",    "test_unit"
-)
-# styler: on
-
-test_level_net <- "net"
-test_level_bo_po <- "bo_po"
-test_level_false <- "foo"
-
-test_output_add_technology_share_by_direction_bo_po <- add_technology_share_by_direction(
-  data = test_data_add_technology_share_by_direction,
-  level = test_level_bo_po
-)
-
-test_that("technology shares by direction within a sector are calculated correctly", {
-  expect_equal(
-    test_output_add_technology_share_by_direction_bo_po$direction,
-    test_data_add_technology_share_by_direction$direction
-  )
-  expect_equal(
-    test_output_add_technology_share_by_direction_bo_po$technology_share_by_direction,
-    c(0.6, 0.6, 0.4, 0.5, 0.5)
-  )
-})
-
-test_output_add_technology_share_by_direction_net <- add_technology_share_by_direction(
-  data = test_data_add_technology_share_by_direction,
-  level = test_level_net
-)
-
-test_that("technology shares by direction within a sector are calculated correctly", {
-  expect_equal(
-    test_output_add_technology_share_by_direction_net$direction,
-    rep.int("net", times = nrow(test_data_add_technology_share_by_direction))
-  )
-  expect_equal(
-    test_output_add_technology_share_by_direction_net$technology_share_by_direction,
-    rep.int(1, times = nrow(test_data_add_technology_share_by_direction))
-  )
-})
-
-test_that("technology shares by direction error gracefully with wrong input level", {
-  expect_error(
-    {
-      add_technology_share_by_direction(
-        data = test_data_add_technology_share_by_direction,
-        level = test_level_false
-      )
-    },
-    "Invalid input provided for argument: level."
-  )
-})
-
 ## add_net_absolute_scenario_value----
 # styler: off
 test_data_add_net_absolute_scenario_value <- tibble::tribble(
@@ -409,19 +349,16 @@ test_that("add_net_absolute_scenario_value adds sum of scenario values as expect
 ## add_total_deviation----
 # styler: off
 test_data_add_total_deviation_bo_po <- tibble::tribble(
-     ~group_id,     ~name_abcd, ~scenario_source,     ~region,        ~sector, ~technology, ~activity_unit, ~year, ~net_absolute_scenario_value, ~direction, ~total_tech_deviation, ~technology_share_by_direction,
-  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_A",  "output unit",  2027,                          100, "buildout",                    -5,                            0.1,
-  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_B",  "output unit",  2027,                          100, "phaseout",                    10,                            0.9,
-  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_C",  "output unit",  2027,                          100, "phaseout",                   -10,                            0.9,
-  "test_group", "test_company",    "test_source", "somewhere", "other_sector",    "tech_X",  "output unit",  2027,                           30, "buildout",                   -20,                            0.8,
-  "test_group", "test_company",    "test_source", "somewhere", "other_sector",    "tech_Y",  "output unit",  2027,                           30, "phaseout",                     5,                            0.2
+     ~group_id,     ~name_abcd, ~scenario_source,     ~region,        ~sector, ~technology, ~activity_unit, ~year, ~net_absolute_scenario_value, ~direction, ~total_tech_deviation,
+  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_A",  "output unit",  2027,                          100, "buildout",                    -5,
+  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_B",  "output unit",  2027,                          100, "phaseout",                    10,
+  "test_group", "test_company",    "test_source", "somewhere",  "test_sector",    "tech_C",  "output unit",  2027,                          100, "phaseout",                   -10,
+  "test_group", "test_company",    "test_source", "somewhere", "other_sector",    "tech_X",  "output unit",  2027,                           30, "buildout",                   -20,
+  "test_group", "test_company",    "test_source", "somewhere", "other_sector",    "tech_Y",  "output unit",  2027,                           30, "phaseout",                     5
 )
 # styler: on
 test_data_add_total_deviation_net <- test_data_add_total_deviation_bo_po %>%
-  dplyr::mutate(
-    direction = "net",
-    technology_share_by_direction = 1
-  )
+  dplyr::mutate(direction = "net")
 
 test_output_add_total_deviation_bo_po <- add_total_deviation(
   data = test_data_add_total_deviation_bo_po
@@ -444,10 +381,10 @@ test_that("add_total_deviation adds deviation by sector and direction as expecte
 ## calculate_company_alignment_metric----
 # styler: off
 test_data_calculate_company_alignment_metric <- tibble::tribble(
-     ~group_id,     ~name_abcd,    ~sector, ~activity_unit,     ~region, ~scenario_source, ~year, ~direction, ~total_deviation, ~technology_share_by_direction, ~net_absolute_scenario_value,
-  "test_group", "test_company", "sector_a",  "output_unit", "somewhere",    "that_source",  2027,      "net",               20,                              1,                           40,
-  "test_group", "test_company", "sector_b",  "output_unit", "somewhere",    "that_source",  2027,      "net",               50,                              1,                           40,
-  "test_group", "some_company", "sector_a",  "output_unit", "somewhere",    "that_source",  2027,      "net",               30,                              1,                           30
+     ~group_id,     ~name_abcd,    ~sector, ~activity_unit,     ~region, ~scenario_source, ~year, ~direction, ~total_deviation, ~net_absolute_scenario_value,
+  "test_group", "test_company", "sector_a",  "output_unit", "somewhere",    "that_source",  2027,      "net",               20,                           40,
+  "test_group", "test_company", "sector_b",  "output_unit", "somewhere",    "that_source",  2027,      "net",               50,                           40,
+  "test_group", "some_company", "sector_a",  "output_unit", "somewhere",    "that_source",  2027,      "net",               30,                           30
 )
 # styler: on
 test_scenario <- "some_scenario"
@@ -486,7 +423,7 @@ test_output_calculate_company_aggregate_alignment_sda <- calculate_company_aggre
   time_frame = test_time_frame
 )
 
-added_columns <- c("activity_unit", "scenario", "direction", "total_deviation", "technology_share_by_direction", "alignment_metric")
+added_columns <- c("activity_unit", "scenario", "direction", "total_deviation", "alignment_metric")
 dropped_columns <- c("emission_factor_metric", "emission_factor_value")
 expected_output_columns <- c(names(test_data_calculate_company_aggregate_alignment_sda), added_columns)
 expected_output_columns <- expected_output_columns[!expected_output_columns %in% dropped_columns]
@@ -575,7 +512,7 @@ test_output_prep_and_wrangle_aggregate_alignment_sda_1 <- prep_and_wrangle_aggre
 )
 
 test_output_cols <- names(test_output_prep_and_wrangle_aggregate_alignment_sda_1)
-expected_output_cols <- c(names(test_data_prep_and_wrangle_aggregate_alignment_sda_1), "projected", test_target_scenario)
+expected_output_cols <- c(names(test_data_prep_and_wrangle_aggregate_alignment_sda_1), "projected", test_target_scenario, "direction")
 expected_output_cols <- expected_output_cols[!expected_output_cols %in% c("emission_factor_metric", "emission_factor_value")]
 
 test_that("output columns replace emission_factor_* cols with projected and target_scenario", {

--- a/vignettes/company_alignment_metric.Rmd
+++ b/vignettes/company_alignment_metric.Rmd
@@ -143,11 +143,3 @@ $$y_{b,c,t}^* = \dfrac{\Delta total_{b,c,t}^*}{s_{b,c,t}}$$
 
 The company alignment metric for emissions intensity sectors $y_{b,c,t}^*$ follows a similar logic as the one for sectors with technology pathways, in that it measures the percent deviation of the emissions intensity in time $t$ for a company from its scenario-based emissions intensity at time $t$. Again, this means that $y_{b,c,t}^* = 0$ describes a company that is right on track with with its emissions intensity relative to the scenario-based value, whereas $y_{b,c,t}^* = 1$ means the emissions intensity is one hundred percent better (lower) than required by the scenario value and $y_{b,c,t}^* = -0.5$ means that the emissions intensity is fifty percent worse (higher) than implied by the scenario value. There is no disaggregation of emissions intensity based metrics, as these are calculated on the sector level to begin with.
 
-### 2.5 The technology share for weighting of build out and phase out
-
-In a later chapter, we discuss how to aggregate company level alignment metrics to the portfolio level. Given the need to calculate aggregations by build out and phase out technologies, we will need to be able to split company weights into
-$BO$ and $PO$ components. For that, we will need the company level information of the technology share of company $c$ for direction $d$ in sector $b$ at time $t$, which we calculate as:
-
-$$technology \: share_{b,c,d,t} = \dfrac{\sum_{\forall a \in b,d} p_{a,b,c,d,t}}{p_{b,c,t}}$$
-The technology share by direction is only used later when disaggregating the net alignment metric into the build out and phase out components as described in the section on [portfolio aggregated alignment metrics](https://rmi-pacta.github.io/pacta.aggregate.loanbook.plots/articles/loanbook_aggregated_alignment_metric.html).
-

--- a/vignettes/loanbook_aggregated_alignment_metric.Rmd
+++ b/vignettes/loanbook_aggregated_alignment_metric.Rmd
@@ -40,11 +40,6 @@ The exposure-weighted net (or buildout/phaseout) alignment for a given loan book
 Loan exposure $l$ (debt outstanding) of bank $n$ to company $c$ in sector $b$, at time $t = 0$:
 
 $$l_{n,b,c,t = 0}$$
-In aggregating the buildout/phaseout values, an approximation of how the loan exposure is split between the buildout/phaseout technologies within a sector is made based on the technology share and is calculated as follows:
-
-$$l_{n,b,c,d,t = 0} = l_{n,b,c,t = 0} \times technology \: share_{b,c,d,t = 5}$$
-
-The technology share is calculated based on the company’s production plan values 5 years forward looking. This reflects splitting the loan by the company's planned future technology mix in $t=5$. This is preferred over taking the technology share at the start year as this may lead to loans not being split if a company has no technology capacity in the start year but ambitious buildout plans for year 5. Moreover, for a company that plans to build out capacity for a given technology beyond the start year to appear in the asset based company-level data set they will have committed capital towards it in the start year.
 
 ### 2.2 Aggregating the company/sector level metric to the loan book/sector level
 
@@ -54,12 +49,12 @@ $$Y_{n,b,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{c} l_{n,b,c,t=0}} \times y_{b,c,t}$$
 
 Where applicable the exposure-weighted buildout/phaseout-alignment metric can be calculated as:
 
-$$Y_{n,b,d,t} = \dfrac{l_{n,b,c,d,t=0}}{\sum_{c} l_{n,b,c,d,t=0}} \times y_{b,c,d,t}$$
+$$Y_{n,b,d,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{c} l_{n,b,c,t=0}} \times y_{b,c,d,t}$$
 
 #### Interpretation:
 
 The exposure-weighted net aggregate alignment metric $Y_{n,b,t}$ tells us if the activities of the companies that a loan book is exposed to are, on aggregate, aligned with the scenario-based values for each of the companies in $t = 5$. This should be read as a high-level summary of the alignment in a given loan book and is meant as a prompt for further analysis at more granular levels, especially as an entry into standard PACTA analysis and its metrics as laid out [here](https://rmi-pacta.github.io/r2dii.analysis/articles/r2dii-analysis.html).
 
-Note that this value will be driven largely by the exposure to the relevant companies in the loan book. hence a positive value does not immediately imply the unweighted sum of the counterparties activities is aligned with a given scenario. Instead the exposure-weighted result might be driven by one or more particularly well-performing companies, to which the loan book has significant exposures.
+Note that this value will be driven largely by the exposure to the relevant companies in the loan book. Hence, a positive value does not immediately imply the unweighted sum of the counterparties activities is aligned with a given scenario. Instead, the exposure-weighted result might be driven by one or more particularly well-performing companies, to which the loan book has significant exposures.
 
 Note also that a disaggregation to the buildout and phaseout levels of the exposure-weighted aggregate alignment metric is necessary in sectors with both buildout and phaseout technologies, to understand the drivers of the net value. $Y_{n,b,d,t}$ provides this disaggregation. For unidirectional sectors, the disaggregation is equal to the net value and for emissions intensity based sectors that use the SDA approach, no disaggregation can be computed.


### PR DESCRIPTION
closes #87 

This PR:
- fixes the wrong aggregation of buildout and phaseout alignment metrics, by using the net exposure and dropping the technology share
- accordingly, the technology share is removed from the documentation and the methodology section
- additionally, the aggregation of financial exposure is now limited to the net perspective, because splitting the financial exposure by buildout and phaseout technologies makes too strong assumptions
- the behaviour of the aggregation is now covered by unit tests