### PR TITLE
96 bug correct docu

### DIFF
--- a/vignettes/loanbook_aggregated_alignment_metric.Rmd
+++ b/vignettes/loanbook_aggregated_alignment_metric.Rmd
@@ -31,29 +31,36 @@ Any other level of analysis can be investigated too, using this same approach.
 
 ## 2. Exposure-weighted aggregated alignment metric
 
-To obtain a loan book level aggregation of the company alignment metric, the portfolio weight approach is applied. The exposure weights for each company are derived by dividing the total drawn amount (debt outstanding) loan value as a proportion of the loans to the sector. This assumes the drawn loan amount goes fully towards activity in the given sector.^[Company activity across multiple PACTA sectors can be taken into account using the following approach for [splitting loans in general](https://github.com/RMI-PACTA/workflow.aggregate.loanbooks#optional-calculate-sector-splits-for-multi-sector-energy-companies) and [production based splits for energy companies](https://github.com/RMI-PACTA/workflow.aggregate.loanbooks#methodological-note-sector-split-for-energy-companies).]
+To obtain a loan book level aggregation of the company alignment metric, the portfolio weight approach is applied. The exposure weights for each company in the loan book are derived by dividing the loan value (drawn amount or debt outstanding) of a counterparty by the total loan value of the matched loan book. This assumes the drawn loan amount goes fully towards activity in the given sector.^[Company activity across multiple PACTA sectors can be taken into account using the following approach for [splitting loans in general](https://github.com/RMI-PACTA/workflow.aggregate.loanbooks#optional-calculate-sector-splits-for-multi-sector-energy-companies) and [production based splits for energy companies](https://github.com/RMI-PACTA/workflow.aggregate.loanbooks#methodological-note-sector-split-for-energy-companies).]
 
 ### 2.1 Defining exposure weights at the company/sector level
 
 The exposure-weighted net (or buildout/phaseout) alignment for a given loan book is calculated as follows:
 
-Loan exposure $l$ (debt outstanding) of bank $n$ to company $c$ in sector $b$, at time $t = 0$:
+Loan exposure $l$ (debt outstanding) of bank (or loan book) $n$ to company $c$ in sector $b$, at time $t = 0$:
 
 $$l_{n,b,c,t = 0}$$
 
-### 2.2 Aggregating the company/sector level metric to the loan book/sector level
+### 2.2 Aggregating the company/sector level metric to the loan book by sector level
 
-Giving the exposure-weighted net alignment metric $Y$ at the loan book/sector level, as follows:
+We derive the exposure-weighted company net alignment metric $Y$ at the by sector:
 
-$$Y_{n,b,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{c} l_{n,b,c,t=0}} \times y_{b,c,t}$$
+$$Y_{n,b,c,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{b,c} l_{n,b,c,t=0}} \times y_{b,c,t}$$
+Finally, the exposure-weighted net alignment metric $Y$ at the loan book by sector level follows as:
 
-Where applicable the exposure-weighted buildout/phaseout-alignment metric can be calculated as:
+$$Y_{n,b,t} = \sum_{c} Y_{n,b,c,t} $$
 
-$$Y_{n,b,d,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{c} l_{n,b,c,t=0}} \times y_{b,c,d,t}$$
+Where applicable, we obtain the exposure-weighted buildout/phaseout-alignment metric for each company as:
+
+$$Y_{n,b,c,d,t} = \dfrac{l_{n,b,c,t=0}}{\sum_{b,c} l_{n,b,c,t=0}} \times y_{b,c,d,t}$$
+
+And correspondingly, the exposure-weighted buildout/phaseout-alignment metric can be calculated for the loan book level as:
+
+$$Y_{n,b,d,t} = \sum_{c} Y_{n,b,c,d,t} $$
 
 #### Interpretation:
 
-The exposure-weighted net aggregate alignment metric $Y_{n,b,t}$ tells us if the activities of the companies that a loan book is exposed to are, on aggregate, aligned with the scenario-based values for each of the companies in $t = 5$. This should be read as a high-level summary of the alignment in a given loan book and is meant as a prompt for further analysis at more granular levels, especially as an entry into standard PACTA analysis and its metrics as laid out [here](https://rmi-pacta.github.io/r2dii.analysis/articles/r2dii-analysis.html).
+The exposure-weighted net aggregate alignment metric $Y_{n,b,t}$ tells us if the activities of the companies that a loan book is exposed to in $t = 0$ are, on aggregate, aligned with the scenario-based values for each of the companies in $t = 5$. This should be read as a high-level summary of the alignment in a given loan book and is meant as a prompt for further analysis at more granular levels, especially as an entry into standard PACTA analysis and its metrics as laid out [here](https://rmi-pacta.github.io/r2dii.analysis/articles/r2dii-analysis.html).
 
 Note that this value will be driven largely by the exposure to the relevant companies in the loan book. Hence, a positive value does not immediately imply the unweighted sum of the counterparties activities is aligned with a given scenario. Instead, the exposure-weighted result might be driven by one or more particularly well-performing companies, to which the loan book has significant exposures.
 

--- a/vignettes/loanbook_aggregated_alignment_metric.Rmd
+++ b/vignettes/loanbook_aggregated_alignment_metric.Rmd
@@ -26,7 +26,7 @@ The aggregations described below can be made at any defined level of a loan book
 (1) aggregations to the bank level, to facilitate bank-by-bank comparison and 
 (2) aggregations to the bank group level, to understand patterns common to different types of financial institutions.
 
-Any other level of anylsis can be investigated too, using this same approach.
+Any other level of analysis can be investigated too, using this same approach.
 
 
 ## 2. Exposure-weighted aggregated alignment metric


### PR DESCRIPTION
closes #96 

- Documentation is corrected to explain exposure weight correctly (share of one loan relative to full matched loan book)
- mathematical documentation is adjusted accordingly
- mathematical documentation gains an additional step that was previously sloppily combined into the previous one
  - first calculate exposure weighted alignment metric per company
  - then aggregated the exposure weighted alignment metrics across companies